### PR TITLE
chore: Remove run script with old pattern

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,0 @@
-bundle install
-bundle exec jekyll serve --lsi


### PR DESCRIPTION
* As directly invoking jekyll over using the rake commands in the Rakefile is no longer recommended remove the 'run.sh' script as its top level location in the repository gives it the false appearance of being the default.