### PR TITLE
chore: Add .git-blame-ignore-revs for cleaner blame diffs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: Apply pre-commit hooks
+1f17b4fd21434ab6f69d2dd54a54a63dfb8f35d5


### PR DESCRIPTION
* Commits added to .git-blame-ignore-revs can be ignored in 'git blame' to make the stepping between diffs less noisy. This is automatically applied on GitHub's blame view.