### PR TITLE
feat: Add 'start' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ and then run any defined task with `pixi run`, such as building and serving the 
 pixi run serve
 ```
 
+The canonical
+
+```
+pixi run start
+```
+
+runs the `install` and `serve` tasks.
+
 You can see all the defined tasks in this project by running
 
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,6 +23,8 @@ clean = "bundle exec rake clean"
 
 clobber = "bundle exec rake clobber"
 
+start = { depends-on = ["install", "serve"] }
+
 [dependencies]
 ruby = ">=3.3.3,<4"
 compilers = ">=1.7.0,<2"


### PR DESCRIPTION
* Add canonical 'pixi run start' command that runs the 'install' and 'serve' tasks.